### PR TITLE
Move feedservice s3 settings under storage.s3 and add storage type

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -848,7 +848,7 @@ feedservice:
   ## Configure file storage settings
   ##
   storage:
-    ## Storage type. Supported values are "s3" and "azure".
+    ## Storage type. Supported values: "s3".
     ##
     type: "s3"
     ## Configure S3 access.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -845,30 +845,36 @@ saltmaster:
 ## Feed configuration.
 ##
 feedservice:
-  ## Configure S3 access.
+  ## Configure file storage settings
   ##
-  s3:
-    ## Secret name for S3 credentials.
+  storage:
+    ## Storage type. Supported values are "s3" and "azure".
     ##
-    secretName: "feeds-s3-credentials"
-    ## The name of the S3 bucket that the service should connect to.
+    type: "s3"
+    ## Configure S3 access.
     ##
-    bucket: "systemlink-feeds"
-    ## S3 connection scheme.
-    ##
-    scheme: *s3Scheme
-    ## Set this value to connect to an external S3 instance.
-    ##
-    host: *s3Host
-    ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
-    ##
-    service: *s3ServiceName
-    ## S3 Port
-    ##
-    port: *s3Port
-    ## S3 Region
-    ##
-    region: *s3Region
+    s3:
+      ## Secret name for S3 credentials.
+      ##
+      secretName: "feeds-s3-credentials"
+      ## The name of the S3 bucket that the service should connect to.
+      ##
+      bucket: "systemlink-feeds"
+      ## S3 connection scheme.
+      ##
+      scheme: *s3Scheme
+      ## Set this value to connect to an external S3 instance.
+      ##
+      host: *s3Host
+      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
+      ##
+      service: *s3ServiceName
+      ## S3 Port
+      ##
+      port: *s3Port
+      ## S3 Region
+      ##
+      region: *s3Region
   ## Proxy configuration to be used when the service needs to go through a proxy to have access to external services like ni.com.
   httpProxy:
     ## @param httpProxy.address Address of the HTTP proxy in the $host:$port format. Example: "1.1.1.1:2222"


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

A new storage setting is introduced under `feedservice`. It has a `type` property that specifies the storge service to use.
The s3 setting under `feedservice` is moved under storage.s3

### Why should this Pull Request be merged?

Document new settings with potential breaking behavior. This settings are not supported in the February release so these changes should wait until after that release is completed.

### What testing has been done?
